### PR TITLE
Updated mdvi sync algorithm to correct bug I introduced earlier.

### DIFF
--- a/src/differential_value_iteration/algorithms/mdvi.py
+++ b/src/differential_value_iteration/algorithms/mdvi.py
@@ -55,7 +55,7 @@ class Evaluation(algorithm.Evaluation):
     changes = self.mrp.rewards - self.r_bar + np.dot(self.mrp.transitions,
                                                      self.current_values) - self.current_values
     self.current_values += self.step_size * changes
-    self.r_bar += self.beta * np.sum(changes)
+    self.r_bar += self.beta * changes
     return changes
 
   def update_async(self):

--- a/src/differential_value_iteration/algorithms/mdvi_test.py
+++ b/src/differential_value_iteration/algorithms/mdvi_test.py
@@ -14,19 +14,19 @@ class MDVITest(parameterized.TestCase):
       (False, np.float64),
       (True, np.float64))
   def test_mdvi_sync_converges(self, r_bar_scalar: bool, dtype: np.dtype):
-    tolerance_places = 6 if dtype is np.float32 else 10
+    tolerance_places = 6 if dtype is np.float32 else 8
     environment = micro.create_mrp1(dtype)
     initial_r_bar = 0. if r_bar_scalar else np.full(environment.num_states,
                                                     0., dtype)
     algorithm = mdvi.Evaluation(
         mrp=environment,
-        step_size=.5,
-        beta=.5,
+        step_size=.1,
+        beta=.1,
         initial_r_bar=initial_r_bar,
         initial_values=np.zeros(environment.num_states, dtype=dtype),
         synchronized=True)
 
-    for _ in range(50):
+    for _ in range(200):
       changes = algorithm.update()
     self.assertAlmostEqual(np.sum(np.abs(changes)), 0., places=tolerance_places)
 


### PR DESCRIPTION
The bug affected the algorithm's ability to solve multichain MRPs.

Thanks for pointing this out @yiwan-rl.

I had to reduce tolerances in the tests, but there is a PR coming later than ensures the 64bit precision is used throughout the algorithms that should allow us to move it back up.