### PR TITLE
64bit experiments

### DIFF
--- a/main.py
+++ b/main.py
@@ -49,7 +49,11 @@ def run_mrps(
     max_iters: int,
     epsilon: float,
     plot_dir: str):
-  envs = [micro.mrp1, micro.mrp2, micro.mrp3]
+  envs = [
+      micro.create_mrp1(dtype=np.float32),
+      micro.create_mrp2(dtype=np.float32),
+      micro.create_mrp3(dtype=np.float32),
+  ]
   for env in envs:
     init_v = np.zeros(env.num_states)
     init_r_bar_scalar = 0

--- a/src/differential_value_iteration/algorithms/algorithm.py
+++ b/src/differential_value_iteration/algorithms/algorithm.py
@@ -17,3 +17,7 @@ class Evaluation(abc.ABC):
   @abc.abstractmethod
   def diverged(self) -> bool:
     """Return true if diverged. Prefer false negative to false positives."""
+
+  @abc.abstractmethod
+  def types_ok(self) -> bool:
+    """Sanity check returns False if something has gone wrong with precision."""

--- a/src/differential_value_iteration/algorithms/dvi.py
+++ b/src/differential_value_iteration/algorithms/dvi.py
@@ -17,17 +17,18 @@ class Evaluation(algorithm.Evaluation):
       beta: float,
       synchronized: bool):
     self.mrp = mrp
-    self.initial_values = initial_values.copy()
-    self.initial_r_bar = initial_r_bar
-    self.step_size = step_size
-    self.beta = beta
+    # Ensure internal value types match environment precision.
+    self.initial_values = initial_values.copy().astype(mrp.rewards.dtype)
+    self.initial_r_bar = mrp.rewards.dtype.type(initial_r_bar)
+    self.step_size = mrp.rewards.dtype.type(step_size)
+    self.beta = mrp.rewards.dtype.type(beta)
+
     self.index = 0
     self.synchronized = synchronized
     self.reset()
 
   def reset(self):
     self.current_values = self.initial_values.copy()
-    #  Be careful, if initial_r_bar is NumPy array this might not work.
     self.r_bar = self.initial_r_bar
 
   def diverged(self) -> bool:
@@ -38,6 +39,9 @@ class Evaluation(algorithm.Evaluation):
       logging.warn('r_bar not finite in DVI.')
       return True
     return False
+
+  def types_ok(self) -> bool:
+    return self.r_bar.dtype == self.mrp.rewards.dtype and self.current_values.dtype == self.mrp.rewards.dtype
 
   def update(self) -> np.ndarray:
     if self.synchronized:

--- a/src/differential_value_iteration/algorithms/dvi_test.py
+++ b/src/differential_value_iteration/algorithms/dvi_test.py
@@ -22,11 +22,18 @@ class DVITest(parameterized.TestCase):
 
     for _ in range(50):
       changes = algorithm.update()
-    self.assertAlmostEqual(np.sum(np.abs(changes)), 0., places=tolerance_places)
+
+    with self.subTest('did_not_diverge'):
+      self.assertFalse(algorithm.diverged())
+    with self.subTest('maintained_types'):
+      self.assertTrue(algorithm.types_ok())
+    with self.subTest('converged'):
+      self.assertAlmostEqual(np.sum(np.abs(changes)), 0.,
+                             places=tolerance_places)
 
   @parameterized.parameters(np.float32, np.float64)
   def test_dvi_async_converges(self, dtype: np.dtype):
-    tolerance_places = 7 if dtype is np.float32 else 10
+    tolerance_places = 6 if dtype is np.float32 else 10
     environment = micro.create_mrp1(dtype)
     algorithm = dvi.Evaluation(
         mrp=environment,
@@ -41,7 +48,13 @@ class DVITest(parameterized.TestCase):
       for _ in range(environment.num_states):
         change = algorithm.update()
         change_sum += np.abs(change)
-    self.assertAlmostEqual(change_sum, 0., places=tolerance_places)
+
+    with self.subTest('did_not_diverge'):
+      self.assertFalse(algorithm.diverged())
+    with self.subTest('maintained_types'):
+      self.assertTrue(algorithm.types_ok())
+    with self.subTest('converged'):
+      self.assertAlmostEqual(change_sum, 0., places=tolerance_places)
 
 
 if __name__ == '__main__':

--- a/src/differential_value_iteration/algorithms/mdvi.py
+++ b/src/differential_value_iteration/algorithms/mdvi.py
@@ -9,6 +9,7 @@ from differential_value_iteration.environments import structure
 
 class Evaluation(algorithm.Evaluation):
   """Multichain DVI for prediction, section 3.1.1 in paper."""
+
   def __init__(
       self,
       mrp: structure.MarkovRewardProcess,
@@ -18,14 +19,16 @@ class Evaluation(algorithm.Evaluation):
       beta: float,
       synchronized: bool):
     self.mrp = mrp
-    self.initial_values = initial_values.copy()
+    # Ensure internal value types match environment precision.
+    self.initial_values = initial_values.copy().astype(mrp.rewards.dtype)
     if isinstance(initial_r_bar, np.ndarray):
-      self.initial_r_bar = initial_r_bar.copy()
+      self.initial_r_bar = initial_r_bar.copy().astype(mrp.rewards.dtype)
     else:
       self.initial_r_bar = np.full(shape=mrp.num_states,
-                                   fill_value=initial_r_bar, dtype=np.float32)
-    self.step_size = step_size
-    self.beta = beta
+                                   fill_value=initial_r_bar,
+                                   dtype=mrp.rewards.dtype)
+    self.step_size = mrp.rewards.dtype.type(step_size)
+    self.beta = mrp.rewards.dtype.type(beta)
     self.index = 0
     self.synchronized = synchronized
     self.current_values = None
@@ -45,6 +48,9 @@ class Evaluation(algorithm.Evaluation):
       return True
     return False
 
+  def types_ok(self) -> bool:
+    return self.r_bar.dtype == self.mrp.rewards.dtype and self.current_values.dtype == self.mrp.rewards.dtype
+
   def update(self) -> np.ndarray:
     if self.synchronized:
       return self.update_sync()
@@ -55,7 +61,7 @@ class Evaluation(algorithm.Evaluation):
     changes = self.mrp.rewards - self.r_bar + np.dot(self.mrp.transitions,
                                                      self.current_values) - self.current_values
     self.current_values += self.step_size * changes
-    self.r_bar += self.beta * np.sum(changes)
+    self.r_bar += self.beta * changes
     return changes
 
   def update_async(self):

--- a/src/differential_value_iteration/algorithms/mdvi.py
+++ b/src/differential_value_iteration/algorithms/mdvi.py
@@ -71,6 +71,6 @@ class Evaluation(algorithm.Evaluation):
         self.mrp.transitions[self.index],
         self.current_values) - self.current_values[self.index]
     self.current_values[self.index] += self.step_size * change
-    self.r_bar += self.beta * change
+    self.r_bar[self.index] += self.beta * change
     self.index = (self.index + 1) % self.mrp.num_states
     return change

--- a/src/differential_value_iteration/algorithms/mdvi_test.py
+++ b/src/differential_value_iteration/algorithms/mdvi_test.py
@@ -20,15 +20,22 @@ class MDVITest(parameterized.TestCase):
                                                     0., dtype)
     algorithm = mdvi.Evaluation(
         mrp=environment,
-        step_size=.5,
-        beta=.5,
+        step_size=.1,
+        beta=.1,
         initial_r_bar=initial_r_bar,
         initial_values=np.zeros(environment.num_states, dtype=dtype),
         synchronized=True)
 
-    for _ in range(50):
+    for _ in range(250):
       changes = algorithm.update()
-    self.assertAlmostEqual(np.sum(np.abs(changes)), 0., places=tolerance_places)
+
+    with self.subTest('did_not_diverge'):
+      self.assertFalse(algorithm.diverged())
+    with self.subTest('maintained_types'):
+      self.assertTrue(algorithm.types_ok())
+    with self.subTest('converged'):
+      self.assertAlmostEqual(np.sum(np.abs(changes)), 0.,
+                             places=tolerance_places)
 
   @parameterized.parameters(
       (False, np.float32),
@@ -53,8 +60,13 @@ class MDVITest(parameterized.TestCase):
       for _ in range(environment.num_states):
         change = algorithm.update()
         change_sum += np.abs(change)
-    # This never goes all the way to 0.
-    self.assertAlmostEqual(change_sum, 0., places=tolerance_places)
+
+    with self.subTest('did_not_diverge'):
+      self.assertFalse(algorithm.diverged())
+    with self.subTest('maintained_types'):
+      self.assertTrue(algorithm.types_ok())
+    with self.subTest('converged'):
+      self.assertAlmostEqual(change_sum, 0., places=tolerance_places)
 
 
 if __name__ == '__main__':

--- a/src/differential_value_iteration/algorithms/mdvi_test.py
+++ b/src/differential_value_iteration/algorithms/mdvi_test.py
@@ -55,7 +55,7 @@ class MDVITest(parameterized.TestCase):
     if dtype == np.float64:
       tolerance_places = 8
     else:
-      tolerance_places = 6 if env_constructor == micro.create_mrp2 else 6
+      tolerance_places = 4 if env_constructor == micro.create_mrp2 else 6
     environment = env_constructor(dtype)
     initial_r_bar = 0. if r_bar_scalar else np.full(environment.num_states,
                                                     0., dtype)

--- a/src/differential_value_iteration/algorithms/rvi.py
+++ b/src/differential_value_iteration/algorithms/rvi.py
@@ -16,8 +16,9 @@ class Evaluation(algorithm.Evaluation):
       reference_index: int,
       synchronized: bool):
     self.mrp = mrp
-    self.initial_values = initial_values.copy()
-    self.step_size = step_size
+    # Ensure internal value types match environment precision.
+    self.initial_values = initial_values.copy().astype(mrp.rewards.dtype)
+    self.step_size = mrp.rewards.dtype.type(step_size)
     self.reference_index = reference_index
     self.index = 0
     self.synchronized = synchronized
@@ -31,6 +32,9 @@ class Evaluation(algorithm.Evaluation):
       logging.warn('Current values not finite in RVI.')
       return True
     return False
+
+  def types_ok(self) -> bool:
+    return self.current_values.dtype == self.mrp.rewards.dtype
 
   def update(self) -> np.ndarray:
     if self.synchronized:

--- a/src/differential_value_iteration/algorithms/rvi_test.py
+++ b/src/differential_value_iteration/algorithms/rvi_test.py
@@ -22,7 +22,14 @@ class RVITest(parameterized.TestCase):
 
     for _ in range(50):
       changes = algorithm.update()
-    self.assertAlmostEqual(np.sum(np.abs(changes)), 0., places=tolerance_places)
+
+    with self.subTest('did_not_diverge'):
+      self.assertFalse(algorithm.diverged())
+    with self.subTest('maintained_types'):
+      self.assertTrue(algorithm.types_ok())
+    with self.subTest('converged'):
+      self.assertAlmostEqual(np.sum(np.abs(changes)), 0.,
+                             places=tolerance_places)
 
   @parameterized.parameters(np.float32, np.float64)
   def test_rvi_async_converges(self, dtype: np.dtype):
@@ -40,7 +47,13 @@ class RVITest(parameterized.TestCase):
       for _ in range(environment.num_states):
         change = algorithm.update()
         change_sum += np.abs(change)
-    self.assertAlmostEqual(change_sum, 0., places=tolerance_places)
+
+    with self.subTest('did_not_diverge'):
+      self.assertFalse(algorithm.diverged())
+    with self.subTest('maintained_types'):
+      self.assertTrue(algorithm.types_ok())
+    with self.subTest('converged'):
+      self.assertAlmostEqual(change_sum, 0., places=tolerance_places)
 
 
 if __name__ == '__main__':

--- a/src/differential_value_iteration/environments/micro.py
+++ b/src/differential_value_iteration/environments/micro.py
@@ -35,8 +35,8 @@ def create_mrp2(dtype: np.dtype):
           [0, .9, .1, 0],
           [.1, 0, .9, 0],
           [.9, .1, 0, 0],
-          [0, 0, 0, 1]], dtype=np.float32),
-      rewards=np.array([0, 1, 8, 20], dtype=np.float32),
+          [0, 0, 0, 1]], dtype=dtype),
+      rewards=np.array([0, 1, 8, 20], dtype=dtype),
       name=f'mrp2 ({dtype.__name__})')
 
 
@@ -52,8 +52,8 @@ def create_mrp3(dtype: np.dtype):
   return structure.MarkovRewardProcess(
       transitions=np.array([
           [.2, .8],
-          [.2, .8]], dtype=np.float32),
-      rewards=np.array([1, 1], dtype=np.float32),
+          [.2, .8]], dtype=dtype),
+      rewards=np.array([1, 1], dtype=dtype),
       name=f'mrp3 ({dtype.__name__})')
 
 

--- a/src/differential_value_iteration/environments/micro.py
+++ b/src/differential_value_iteration/environments/micro.py
@@ -2,34 +2,60 @@ import numpy as np
 from differential_value_iteration.environments import structure
 
 
-def create_mrp1(dtype: np.dtype):
+def create_mrp1(dtype: np.dtype) -> structure.MarkovRewardProcess:
+  """Creates a cycling 3-state MRP from Sutton's book (Exercise 10.7)
+   http://incompleteideas.net/book/RLbook2020.pdf
+
+   Args:
+     dtype: Dtype for reward/transition matrices: np.float32/np.float64
+
+   Returns:
+     The MRP.
+   """
   return structure.MarkovRewardProcess(
       transitions=np.array([
           [0, 1, 0],
           [0, 0, 1],
           [1, 0, 0]
       ], dtype=dtype), rewards=np.array([0, 0, 1], dtype=dtype),
-      name='mrp1')
+      name=f'mrp1 ({dtype.__name__})')
 
 
-# Exercise 10.7 from http://incompleteideas.net/book/RLbook2020.pdf
-mrp1 = create_mrp1(np.float32)
+def create_mrp2(dtype: np.dtype):
+  """Creates a multichain 4-state MRP.
 
-mrp2 = structure.MarkovRewardProcess(
-    transitions=np.array([
-        [0, .9, .1, 0],
-        [.1, 0, .9, 0],
-        [.9, .1, 0, 0],
-        [0, 0, 0, 1]], dtype=np.float32),
-    rewards=np.array([0, 1, 8, 20], dtype=np.float32),
-    name='mrp2')
+   Args:
+     dtype: Dtype for reward/transition matrices: np.float32/np.float64
 
-mrp3 = structure.MarkovRewardProcess(
-    transitions=np.array([
-        [.2, .8],
-        [.2, .8]], dtype=np.float32),
-    rewards=np.array([1, 1], dtype=np.float32),
-    name='mrp3')
+   Returns:
+     The MRP.
+   """
+  return structure.MarkovRewardProcess(
+      transitions=np.array([
+          [0, .9, .1, 0],
+          [.1, 0, .9, 0],
+          [.9, .1, 0, 0],
+          [0, 0, 0, 1]], dtype=np.float32),
+      rewards=np.array([0, 1, 8, 20], dtype=np.float32),
+      name=f'mrp2 ({dtype.__name__})')
+
+
+def create_mrp3(dtype: np.dtype):
+  """Creates a unichain 2-state MRP.
+
+   Args:
+     dtype: Dtype for reward/transition matrices: np.float32/np.float64
+
+   Returns:
+     The MRP.
+   """
+  return structure.MarkovRewardProcess(
+      transitions=np.array([
+          [.2, .8],
+          [.2, .8]], dtype=np.float32),
+      rewards=np.array([1, 1], dtype=np.float32),
+      name=f'mrp3 ({dtype.__name__})')
+
 
 mdp1 = structure.MarkovDecisionProcess(transitions=np.array([
     [[1, 0], [0, 1]],  # first action

--- a/src/differential_value_iteration/environments/structure.py
+++ b/src/differential_value_iteration/environments/structure.py
@@ -28,6 +28,9 @@ class MarkovRewardProcess:
     if self.transitions.shape[0] != self.rewards.shape[0]:
       raise ValueError(
           f'mrp transition and reward states do not match: {self.transitions.shape} vs. {self.rewards.shape}')
+    if self.transitions.dtype != self.rewards.dtype:
+      raise ValueError(
+          f'mrp transition and reward dtypes do not match: {self.transitions.dtype.__name__} vs {self.rewards.dtype.__name__}')
 
     # Ensure transition probabilities sum to 1 for all states.
     state_probability_sums = self.transitions.sum(axis=-1)
@@ -69,6 +72,9 @@ class MarkovDecisionProcess:
     if self.transitions.shape[1] != self.rewards.shape[1]:
       raise ValueError(
           f'mdp transition and reward states do not match: {self.transitions.shape} vs. {self.rewards.shape}')
+    if self.transitions.dtype != self.rewards.dtype:
+      raise ValueError(
+          f'mdp transition and reward dtypes do not match: {self.transitions.dtype.__name__} vs {self.rewards.dtype.__name__}')
 
     # Ensure transition probabilities sum to 1 for all actions and states.
     for action_idx, transitions in enumerate(self.transitions):

--- a/src/differential_value_iteration/experiments/evaluation_convergence.py
+++ b/src/differential_value_iteration/experiments/evaluation_convergence.py
@@ -24,6 +24,7 @@ _MINIMUM_STEP_SIZE = flags.DEFINE_float('minimum_step_size', .001, 'Minimum step
 _MAXIMUM_STEP_SIZE = flags.DEFINE_float('maximum_step_size', 1., 'Maximum step size.')
 _NUM_STEP_SIZES = flags.DEFINE_integer('num_step_sizes', 10, 'Number of step sizes to try.')
 _SYNCHRONIZED = flags.DEFINE_bool('synchronized', True, 'Run algorithms in synchronized mode.')
+_64bit = flags.DEFINE_bool('64bit', False, 'Use 64 bit precision (default is 32 bit).')
 
 _CONVERGENCE_TOLERANCE = flags.DEFINE_float('convergence_tolerance', 1e-5, 'Tolerance for convergence.')
 
@@ -141,12 +142,14 @@ def main(argv):
       endpoint=True)
 
   environments = []
+  problem_dtype = np.float64 if _64bit.value else np.float32
   if _MRP1.value:
-    environments.append(micro.mrp1)
+    environments.append(micro.create_mrp1(dtype=problem_dtype))
   if _MRP2.value:
-    environments.append(micro.mrp2)
+    environments.append(micro.create_mrp2(dtype=problem_dtype))
   if _MRP3.value:
-    environments.append(micro.mrp3)
+    environments.append(micro.create_mrp3(dtype=problem_dtype))
+
   if not environments:
     raise ValueError('At least one environment required.')
 

--- a/src/differential_value_iteration/import_test.py
+++ b/src/differential_value_iteration/import_test.py
@@ -17,8 +17,7 @@ class DifferentialValueIterationTest(absltest.TestCase):
     self.assertTrue(algorithms.MDVI_Control2)
 
   def test_environments_package_import(self):
-    self.assertTrue(micro.mrp1)
-    self.assertTrue(micro.mrp2)
+    self.assertTrue(micro.create_mrp1)
     self.assertTrue(micro.mdp1)
     self.assertTrue(micro.mdp2)
 


### PR DESCRIPTION
- adds thorough type setup to make sure 64 vs 32 bit precision is matched throughout algorithms to match environment
- all MRPs now support 64 bit
- experiment fully supports 64 bit for all mrps
- added mrp2 test for mdvi. It converges (same tolerance as mrp1 in 64 bit, lower tolerance (4 decimal places vs 6)  for mrp2.

Note: could not get async mdvi to get anywhere close to converge in mrp2.
@yiwan-rl @abhisheknaik96  Not sure if this is expected, or perhaps another bug in my port. Repro:
```
python3 src/differential_value_iteration/experiments/evaluation_convergence.py --nodvi --norvi --nomrp1 --nomrp3 --64bit --nosynchronized
```
