### PR TITLE
added a flag to save final estimates

### DIFF
--- a/src/differential_value_iteration/algorithms/algorithm.py
+++ b/src/differential_value_iteration/algorithms/algorithm.py
@@ -2,6 +2,7 @@
 import abc
 
 import numpy as np
+from typing import Dict, Union
 
 
 class Evaluation(abc.ABC):
@@ -21,3 +22,7 @@ class Evaluation(abc.ABC):
   @abc.abstractmethod
   def types_ok(self) -> bool:
     """Sanity check returns False if something has gone wrong with precision."""
+
+  @abc.abstractmethod
+  def get_estimates(self) -> Dict[str, Union[np.ndarray, float]]:
+    """Returns estimated quantities in a dictionary."""

--- a/src/differential_value_iteration/algorithms/dvi.py
+++ b/src/differential_value_iteration/algorithms/dvi.py
@@ -63,3 +63,6 @@ class Evaluation(algorithm.Evaluation):
     self.r_bar += self.beta * change
     self.index = (self.index + 1) % self.mrp.num_states
     return change
+
+  def get_estimates(self):
+    return {'v': self.current_values, 'r_bar': self.r_bar}

--- a/src/differential_value_iteration/algorithms/mdvi.py
+++ b/src/differential_value_iteration/algorithms/mdvi.py
@@ -74,3 +74,6 @@ class Evaluation(algorithm.Evaluation):
     self.r_bar[self.index] += self.beta * change
     self.index = (self.index + 1) % self.mrp.num_states
     return change
+
+  def get_estimates(self):
+    return {'v': self.current_values, 'r_bar': self.r_bar}

--- a/src/differential_value_iteration/algorithms/rvi.py
+++ b/src/differential_value_iteration/algorithms/rvi.py
@@ -57,3 +57,6 @@ class Evaluation(algorithm.Evaluation):
     self.current_values[self.index] += self.step_size * change
     self.index = (self.index + 1) % self.mrp.num_states
     return change
+
+  def get_estimates(self):
+    return {'v': self.current_values, 'r_bar': self.current_values[self.reference_index]}


### PR DESCRIPTION
To get started with #34, I have added a flag to save the learned estimates to an npy file. This will let us compare the learned estimates to some golden values stored elsewhere. 

This is a sample implementation — there are several things that can be done differently (e.g., the accessibility of the name of the file being stored; the save location can be a command-line argument; we can store the experiment results in the file as well). Hence, I've only implemented the `get_estimates` function for MDVI right now (that's why the tests for DVI and RVI are failing). We can discuss and converge to a better alternative implementation.