### PR TITLE
Adds quick port of MDVI Control 2.

### DIFF
--- a/src/differential_value_iteration/algorithms/mdvi_test.py
+++ b/src/differential_value_iteration/algorithms/mdvi_test.py
@@ -90,16 +90,18 @@ class MDVIControlTest(parameterized.TestCase):
 
   @parameterized.parameters(itertools.product(
       (micro.create_mdp1, micro.create_mdp2, _GARET1, _GARET2, _GARET3),
+      (mdvi.Control1, mdvi.Control2),
       (False, True),
       (np.float32, np.float64)))
   def test_mdvi_sync_converges(self,
       mdp_constructor: Callable[[np.dtype], structure.MarkovDecisionProcess],
+      alg_constructor,
       r_bar_scalar: bool, dtype: np.dtype):
     tolerance_places = 6 if dtype == np.float64 else 5
     environment = mdp_constructor(dtype=dtype)
     initial_r_bar = 0. if r_bar_scalar else np.full(environment.num_states,
                                                     0., dtype)
-    algorithm = mdvi.Control1(
+    algorithm = alg_constructor(
         mdp=environment,
         step_size=.1,
         beta=.1,
@@ -124,16 +126,18 @@ class MDVIControlTest(parameterized.TestCase):
 
   @parameterized.parameters(itertools.product(
       (micro.create_mdp1, micro.create_mdp2, _GARET1, _GARET2, _GARET3),
+      (mdvi.Control1, mdvi.Control2),
       (False, True),
       (np.float32, np.float64)))
   def test_mdvi_async_converges(self,
       mdp_constructor: Callable[[np.dtype], structure.MarkovDecisionProcess],
+      alg_constructor,
       r_bar_scalar: bool, dtype: np.dtype):
     tolerance_places = 4 if dtype == np.float64 else 3
     environment = mdp_constructor(dtype=dtype)
     initial_r_bar = 0. if r_bar_scalar else np.full(environment.num_states,
                                                     0., dtype)
-    algorithm = mdvi.Control1(
+    algorithm = alg_constructor(
         mdp=environment,
         step_size=.1,
         beta=.1,

--- a/src/differential_value_iteration/algorithms/policy_test.py
+++ b/src/differential_value_iteration/algorithms/policy_test.py
@@ -118,7 +118,7 @@ class PolicyTest(parameterized.TestCase):
                                     mdvi_control_1.greedy_policy())
     with self.subTest('mdvi1 vs mdvi2'):
       np.testing.assert_array_equal(mdvi_control_1.greedy_policy(),
-                                    mdvi_control_2.greedy_policy())\
+                                    mdvi_control_2.greedy_policy())
 
   @parameterized.parameters(itertools.product(
       (_GARET1,),

--- a/src/differential_value_iteration/algorithms/policy_test.py
+++ b/src/differential_value_iteration/algorithms/policy_test.py
@@ -1,4 +1,4 @@
-"""Tests that our control algorithms find same policy ontest problems."""
+"""Tests that our control algorithms find same policy on test problems."""
 import itertools
 from typing import Callable
 
@@ -57,6 +57,7 @@ class PolicyTest(parameterized.TestCase):
       rvi_control.update()
       dvi_control.update()
       mdvi_control_1.update()
+      mdvi_control_2.update()
     with self.subTest('rvi vs dvi'):
       np.testing.assert_array_equal(rvi_control.greedy_policy(),
                                     dvi_control.greedy_policy())
@@ -66,6 +67,74 @@ class PolicyTest(parameterized.TestCase):
     with self.subTest('mdvi1 vs mdvi2'):
       np.testing.assert_array_equal(mdvi_control_1.greedy_policy(),
                                     mdvi_control_2.greedy_policy())
+
+  @parameterized.parameters(itertools.product(
+      (_GARET1,),
+      (np.float32,)))
+  def test_identical_policies_sync(self,
+      mdp_constructor: Callable[[np.dtype], structure.MarkovDecisionProcess],
+      dtype: np.dtype):
+    """Not useful now, can be used to compare return from different policies."""
+    environment = mdp_constructor(dtype=dtype)
+    mdvi_control_1 = mdvi.Control1(
+        mdp=environment,
+        step_size=.1,
+        beta=.1,
+        threshold=.1,
+        initial_r_bar=0.,
+        initial_values=np.zeros(environment.num_states, dtype=dtype),
+        synchronized=True)
+    mdvi_control_2 = mdvi.Control2(
+        mdp=environment,
+        step_size=.1,
+        beta=.1,
+        threshold=.1,
+        initial_r_bar=0.,
+        initial_values=np.zeros(environment.num_states, dtype=dtype),
+        synchronized=True)
+    for i in range(500):
+      mdvi_control_1.update()
+      mdvi_control_2.update()
+
+    control_1_policy = mdvi_control_1.greedy_policy()
+    control_2_policy = mdvi_control_2.greedy_policy()
+    differences = np.sum(np.where(control_1_policy == control_2_policy, 0, 1))
+    with self.subTest('policies match'):
+      self.assertEqual(differences, 0)
+
+    # Tuples are better for array indexing.
+    control_1_policy = tuple(control_1_policy)
+    control_2_policy = tuple(control_2_policy)
+
+    initial_state_distribution = np.zeros(environment.num_states, np.float32)
+    # Start from State 1
+    initial_state_distribution[0] = 1.
+    iterations = 100
+    control_1_return = generate_rewards(environment,
+                                        control_1_policy,
+                                        iterations=iterations,
+                                        initial_state_distribution=initial_state_distribution)
+    control_2_return = generate_rewards(environment,
+                                        control_2_policy,
+                                        iterations=iterations,
+                                        initial_state_distribution=initial_state_distribution)
+    with self.subTest('returns match'):
+      self.assertAlmostEqual(control_1_return, control_2_return)
+
+
+def generate_rewards(environment: structure.MarkovDecisionProcess,
+    policy: np.ndarray, iterations: int,
+    initial_state_distribution: np.ndarray):
+  total_return = 0.
+  policy_rewards = environment.rewards[
+    policy, np.arange(0, environment.num_states)]
+  policy_transitions = environment.transitions[policy, :,
+                       np.arange(0, environment.num_states)]
+  state_distribution = initial_state_distribution.copy()
+  for _ in range(iterations):
+    total_return += np.dot(policy_rewards, state_distribution)
+    state_distribution = np.dot(policy_transitions, state_distribution)
+  return total_return / iterations
 
 
 if __name__ == '__main__':

--- a/src/differential_value_iteration/algorithms/policy_test.py
+++ b/src/differential_value_iteration/algorithms/policy_test.py
@@ -45,7 +45,14 @@ class PolicyTest(parameterized.TestCase):
         initial_r_bar=0.,
         initial_values=np.zeros(environment.num_states, dtype=dtype),
         synchronized=True)
-
+    mdvi_control_2 = mdvi.Control2(
+        mdp=environment,
+        step_size=.1,
+        beta=.1,
+        threshold=.1,
+        initial_r_bar=0.,
+        initial_values=np.zeros(environment.num_states, dtype=dtype),
+        synchronized=True)
     for i in range(500):
       rvi_control.update()
       dvi_control.update()
@@ -56,6 +63,9 @@ class PolicyTest(parameterized.TestCase):
     with self.subTest('rvi vs mdvi1'):
       np.testing.assert_array_equal(rvi_control.greedy_policy(),
                                     mdvi_control_1.greedy_policy())
+    with self.subTest('mdvi1 vs mdvi2'):
+      np.testing.assert_array_equal(mdvi_control_1.greedy_policy(),
+                                    mdvi_control_2.greedy_policy())
 
 
 if __name__ == '__main__':

--- a/src/differential_value_iteration/experiments/control_benchmark.py
+++ b/src/differential_value_iteration/experiments/control_benchmark.py
@@ -110,12 +110,18 @@ def main(argv):
     algorithm_constructors.append(dvi_algorithm)
 
   if FLAGS.mdvi:
-    mdvi_algorithm = functools.partial(mdvi.Control1,
-                                       step_size=.1,
-                                       beta=.1,
-                                       initial_r_bar=0.,
-                                       threshold=.1)
-    algorithm_constructors.append(mdvi_algorithm)
+    mdvi_algorithm_1 = functools.partial(mdvi.Control1,
+                                         step_size=.1,
+                                         beta=.1,
+                                         initial_r_bar=0.,
+                                         threshold=.1)
+    algorithm_constructors.append(mdvi_algorithm_1)
+    mdvi_algorithm_2 = functools.partial(mdvi.Control2,
+                                         step_size=.1,
+                                         beta=.1,
+                                         initial_r_bar=0.,
+                                         threshold=.1)
+    algorithm_constructors.append(mdvi_algorithm_2)
   if FLAGS.rvi:
     rvi_algorithm = functools.partial(rvi.Control,
                                       step_size=.1,


### PR DESCRIPTION
Tests are updated to run with MDVI Control 2.

Control 1 and 2 converge to *something* on all of the same problems with the same hypers.

@abhisheknaik96  @yiwan-rl  

However, in policy_test.py, MDVI Control 1 , RVI, DVI converge to the SAME policies on:
MDP1, MDP2, GARET 1/2/3.

MDVI Control 2 DOES NOT converge to the same policy as MDVI Control1 on 2 of the GARET tasks.

I have not dug into this at all yet. Just trying to get some progress updates to you folks at the end of my day!


